### PR TITLE
Adding test coverage to backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 web-client/app/scripts/appConfig.js
 web-client/test/spec/helpers/cachedTemplates.js
 web-client/coverage
+
+backend/coverage

--- a/backend/Gemfile
+++ b/backend/Gemfile
@@ -35,4 +35,5 @@ group :test, :development do
   gem 'guard-rspec'
   gem 'factory_girl_rails'
   gem 'email_spec'
+  gem 'simplecov', :require => false
 end

--- a/backend/Gemfile.lock
+++ b/backend/Gemfile.lock
@@ -40,6 +40,7 @@ GEM
       thread_safe (~> 0.1)
       warden (~> 1.2.3)
     diff-lcs (1.2.5)
+    docile (1.1.1)
     dotenv (0.9.0)
     dotenv-rails (0.9.0)
       dotenv (= 0.9.0)
@@ -166,6 +167,11 @@ GEM
       rspec-expectations (~> 2.14.0)
       rspec-mocks (~> 2.14.0)
     ruby-hmac (0.4.0)
+    simplecov (0.8.2)
+      docile (~> 1.1.0)
+      multi_json
+      simplecov-html (~> 0.8.0)
+    simplecov-html (0.8.0)
     slop (3.4.7)
     sprockets (2.10.1)
       hike (~> 1.2)
@@ -212,4 +218,5 @@ DEPENDENCIES
   rails-api
   rails_12factor
   rspec-rails
+  simplecov
   therubyracer

--- a/backend/spec/spec_helper.rb
+++ b/backend/spec/spec_helper.rb
@@ -1,3 +1,6 @@
+require 'simplecov'
+SimpleCov.start 'rails'
+
 # This file is copied to spec/ when you run 'rails generate rspec:install'
 ENV["RAILS_ENV"] ||= 'test'
 require File.expand_path("../../config/environment", __FILE__)


### PR DESCRIPTION
Using simplecov for coverage reports on the backend. 

The reports are generated in coverage/ folder. So just open the index.html file in there and you can read the coverage.