### PR TITLE
Use Default Scope with a block

### DIFF
--- a/backend/app/models/article.rb
+++ b/backend/app/models/article.rb
@@ -1,7 +1,7 @@
 class Article < ActiveRecord::Base
   include Utils
 
-  default_scope order('created_at DESC')
+  default_scope { order('created_at DESC') }
   belongs_to :user
   has_many :recommendations, :dependent => :destroy
 


### PR DESCRIPTION
Calling #default_scope without a block is deprecated. For example instead of `default_scope where(color: 'red')`, please use `default_scope { where(color: 'red') }`.
