### PR TITLE
Sort articles by popularity before recency for a quick

### DIFF
--- a/backend/app/controllers/api/v1/articles_controller.rb
+++ b/backend/app/controllers/api/v1/articles_controller.rb
@@ -8,7 +8,7 @@ class Api::V1::ArticlesController < ApplicationController
   def index
     # Use the custom Article.public method to return all articles that is
     # marked published.
-    @articles = Article.public
+    @articles = Article.public.top
     render 'api/v1/articles/index'
   end
 

--- a/backend/app/models/article.rb
+++ b/backend/app/models/article.rb
@@ -1,7 +1,9 @@
 class Article < ActiveRecord::Base
   include Utils
 
-  default_scope { order('created_at DESC') }
+  scope :top, -> { order('recommendations_count DESC').order('created_at DESC') }
+  scope :recents, -> { order('created_at DESC') }
+
   belongs_to :user
   has_many :recommendations, :dependent => :destroy
 


### PR DESCRIPTION
This will give top voted articles firsts. 

Better ratings aging for articles is needed so that top articles doesn't stick always to the top. Also, maybe adding a toggle between most recents and populars.
