### PR TITLE
Use smaller dimensions for article card covers and user avatars

### DIFF
--- a/backend/app/views/api/v1/articles/show.rabl
+++ b/backend/app/views/api/v1/articles/show.rabl
@@ -3,10 +3,18 @@ object @article
 attributes :id, :title, :tagline, :body, :created_at, :updated_at, :published, :recommendations_count
 
 
-attribute :cover_abs_url => :cover_url
+attribute :cover_abs_url => :original_cover_url
 
 node :thumb_url do |article|
   article.cover_abs_url '400x400#'
+end
+
+node :cover_url do |article|
+  article.cover_abs_url '1900x1200#'
+end
+
+node :card_cover_url do |article|
+  article.cover_abs_url '1140x270#'
 end
 
 child :user do

--- a/backend/app/views/api/v1/users/show.rabl
+++ b/backend/app/views/api/v1/users/show.rabl
@@ -4,6 +4,10 @@ attributes :id, :name, :bio, :created_at
 
 attribute :avatar_abs_url => :avatar_url
 
+node :cover_url do |user|
+  user.avatar_abs_url '1900x1200#'
+end
+
 node :thumb_url do |user|
   user.avatar_abs_url '400x400#'
 end

--- a/web-client/app/index.html
+++ b/web-client/app/index.html
@@ -54,7 +54,7 @@
     <nav class="site-nav" snap-drawer="left">
       <div class="profile-badge">
         <a href="/#!/profiles/{{currentUser.id}}" snap-close ng-show="isLoggedIn">
-          <img ng-src="{{currentUser.avatar_url}}" ng-show="currentUser"/>
+          <img ng-src="{{currentUser.thumb_url}}" ng-show="currentUser"/>
           <span>{{currentUser.name}}</span>
         </a>
       </div>

--- a/web-client/app/views/main.html
+++ b/web-client/app/views/main.html
@@ -16,7 +16,7 @@
     <div class="article-details article-card card">
       <div class="header">
         <a ng-href="/#!/articles/{{article.id}}">
-          <div class="image-cover" manshar-cover url="{{article.cover_url}}"></div>
+          <div class="image-cover" manshar-cover url="{{article.card_cover_url}}"></div>
         </a>
 
         <div class="title">

--- a/web-client/app/views/profiles/show.html
+++ b/web-client/app/views/profiles/show.html
@@ -1,5 +1,5 @@
 <div class="manshar-profile">
-  <div class="avatar" manshar-cover url="{{user.avatar_url}}">
+  <div class="avatar" manshar-cover url="{{user.cover_url}}">
     <div class="title">
       <h1>{{user.name}}</h1>
       <h4>{{user.bio}}</h4>
@@ -13,7 +13,7 @@
 
       <div class="article-details article-card card">
         <div class="header">
-          <div class="image-cover" manshar-cover url="{{article.cover_url}}"></div>
+          <div class="image-cover" manshar-cover url="{{article.card_cover_url}}"></div>
 
           <div class="title">
             <h1>{{article.title}}</h1>
@@ -35,7 +35,7 @@
 
       <div class="article-details article-card card draft">
         <div class="header">
-          <div class="image-cover" manshar-cover url="{{article.cover_url}}"></div>
+          <div class="image-cover" manshar-cover url="{{article.card_cover_url}}"></div>
 
           <div class="title">
             <h1>{{article.title}}</h1>


### PR DESCRIPTION
This addresses parts of #67 and #68 and avoid loading overblown images in the home page and elsewhere.

Next step would be to enable image optimizations on upload.
