### PR TITLE
Allow grunt server port settings to be passed from the command line

### DIFF
--- a/web-client/Gruntfile.js
+++ b/web-client/Gruntfile.js
@@ -99,7 +99,7 @@ module.exports = function (grunt) {
     // The actual grunt server settings
     connect: {
       options: {
-        port: 9000,
+        port: grunt.option('port') || 9000,
         // Change this to '0.0.0.0' to access the server from outside.
         hostname: 'localhost',
         livereload: 35729,


### PR DESCRIPTION
some developers might have port 9000 busy with another service.
