### PR TITLE
Autosave articles every 5 seconds as drafts to avoid loss of data

### DIFF
--- a/web-client/app/index.html
+++ b/web-client/app/index.html
@@ -116,6 +116,7 @@
 
         <script src="scripts/controllers/mainController.js"></script>
         <script src="scripts/controllers/articleController.js"></script>
+        <script src="scripts/controllers/newArticleController.js"></script>
         <script src="scripts/controllers/editArticleController.js"></script>
         <script src="scripts/controllers/profileController.js"></script>
         <script src="scripts/controllers/passwordController.js"></script>

--- a/web-client/app/scripts/app.js
+++ b/web-client/app/scripts/app.js
@@ -75,7 +75,7 @@ angular.module('webClientApp', [
 
       .when('/articles/new', {
         templateUrl: 'views/articles/edit.html',
-        controller: 'EditArticleCtrl',
+        controller: 'NewArticleCtrl',
         title: 'مقال جديد',
         resolve: checkAccess({
           isPublic: false

--- a/web-client/app/scripts/controllers/editArticleController.js
+++ b/web-client/app/scripts/controllers/editArticleController.js
@@ -1,10 +1,28 @@
 'use strict';
+/* jshint camelcase: false */
 
 angular.module('webClientApp')
-  .controller('EditArticleCtrl', ['$rootScope', '$scope', '$routeParams', '$location', '$analytics', '$window', 'Article',
-      function ($rootScope, $scope, $routeParams, $location, $analytics, $window, Article) {
+  .controller('EditArticleCtrl', ['$rootScope', '$scope', '$routeParams', '$location', '$analytics', '$window', '$interval', '$timeout', 'Article',
+      function ($rootScope, $scope, $routeParams, $location, $analytics, $window, $interval, $timeout, Article) {
 
-    var isEdit = false;
+    var confirmEditMessage = ('هذه العملية ستنقل المقال إلى مسوداتك. يمكنك' +
+        ' نشرها مجدداً بالضغط على نشر. هل تود نقل المقال للمسودات؟');
+
+    var lastSavedArticle = {};
+
+    /**
+     * Checks if the article has been changed since the last time it was saved.
+     * @return {boolean} True if the article has been changed.
+     */
+    var isDirty = function () {
+      // Check if the article has been updated since last edited.
+      var maybeUpdatedArticle = angular.copy($scope.article);
+      // To avoid updating the $scope.article model just remove updated_at
+      // to make sure the updated_at is not compared when checking for changes.
+      delete maybeUpdatedArticle.updated_at;
+      delete lastSavedArticle.updated_at;
+      return !angular.equals(maybeUpdatedArticle, lastSavedArticle);
+    };
 
     /**
      * If the current user is not the owner redirect the user to view.
@@ -23,36 +41,37 @@ angular.module('webClientApp')
     // Load the article if we are editing.
     $scope.article = {};
     if($routeParams.articleId) {
-      isEdit = true;
-      $scope.article = Article.get({'articleId': $routeParams.articleId}, authorizeUser);
+      $scope.article = Article.get({'articleId': $routeParams.articleId}, function (resource) {
+        authorizeUser(resource);
+        lastSavedArticle = angular.copy(resource);
+
+        // Warn the user that editing an article will move it to draft until
+        // they publish it again.
+        $timeout(function () {
+          if (resource.published) {
+            if (!$window.confirm(confirmEditMessage)) {
+              $location.path('/articles/' + resource.id);
+            }
+          }
+        });
+      });
     }
 
 
-    var createSuccess = function (resource) {
-      $scope.inProgress = null;
-      $analytics.eventTrack('Article Created', {
-        category: 'Article',
-        label: resource.title
-      });
-      $location.path('/articles/' + resource.id);
-    };
-
     var updateSuccess = function (resource) {
+      lastSavedArticle = angular.copy(resource);
+      $timeout(function () {
+        $scope.isSaving = false;
+      }, 1000);
       $scope.inProgress = null;
       $analytics.eventTrack('Article Updated', {
         category: 'Article',
         label: resource.title
       });
-      $location.path('/articles/' + resource.id);
-    };
 
-    var createError = function (response) {
-      $scope.inProgress = null;
-      $analytics.eventTrack('Article Create Error', {
-        category: 'Article',
-        label: angular.toJson(response.errors)
-      });
-      $scope.error = 'حدث خطأ في حفظ المقال.';
+      if (resource.published) {
+        $location.path('/articles/' + resource.id);
+      }
     };
 
     var updateError = function (response) {
@@ -84,25 +103,22 @@ angular.module('webClientApp')
      * Saves/Updates article data.
      * @param {Object} article Article data.
      * @param {boolean} published Whether to publish the article or save as a draft.
+     * @param {boolean} silent Whether to flash the controls or not.
      */
-    $scope.saveArticle = function(article, published) {
-      if (!published && article.published) {
-        if (!$window.confirm('هذه العملية ستنقل المقال إلى مسوداتك. يمكنك نشرها مجدداً بالضغط على نشر. هل تود نقل المقال للمسودات؟')) {
-          return;
-        }
-      }
+    $scope.saveArticle = function(article, published, silent) {
       article.published = published;
       var formError = $scope.articleForm.$error;
       if(published && formError && formError.required) {
         $window.alert('تأكد من ادخال جميع المعلومات المطلوبة');
         return;
       }
-      $scope.inProgress = published ? 'publish' : 'save';
-      if(isEdit) {
-        Article.update({ 'articleId': article.id }, { article: article }, updateSuccess, updateError);
-      } else {
-        Article.save({ article: article }, createSuccess, createError);
+      if (!silent) {
+        $scope.inProgress = published ? 'publish' : 'save';
       }
+
+      Article.update(
+          { 'articleId': article.id }, { article: article },
+          updateSuccess, updateError);
     };
 
     /**
@@ -125,29 +141,49 @@ angular.module('webClientApp')
       $scope.inProgress = 'cancel';
       // Warn the user when canceling editing an existing article or when
       // canceling a new article with changed properties.
-      var isDirty = (isEdit || $scope.article.title || $scope.article.cover ||
-                     $scope.article.tagline || $scope.article.body);
-      if (!isDirty || $window.confirm('متأكد من إلغاء المقال؟')) {
+      if (!isDirty() || $window.confirm('متأكد من إلغاء المقال؟')) {
         $location.path('/');
       } else {
         $scope.inProgress = null;
       }
     };
 
+
+    /**
+     * Start the auto save interval and save its promise to destroy it when the
+     * user is done editing.
+     * @return {!angular.$promise} A promise to be notified on each iteration.
+     */
+    var autoSavePromise = $interval(function () {
+      if (!isDirty()) {
+        return;
+      }
+
+      $scope.isSaving = true;
+      $scope.saveArticle($scope.article, false, true);
+    }, 5000);
+
+
     /**
      * When the user logout while in edit mdoe redirect the user,
      */
     var loggedOutunbined = $rootScope.$on('user.loggedOut', function () {
-      var location = '/';
-      if (isEdit) {
-        location = '/articles/' + $routeParams.articleId;
-      }
+      var location = '/articles/' + $routeParams.articleId;
       $location.path(location);
     });
+
+    /**
+     * Make sure to cleanup the binded events and intervals when the user
+     * leaves to another controller.
+     */
+    var onDestroy = function () {
+      $interval.cancel(autoSavePromise);
+      loggedOutunbined();
+    };
 
     // Make sure to cleanup the binding. Otherwise the event listener will
     // be added everytime the controller load and when the controller is
     // still loaded it would still listen to the event.
-    $scope.$on('$destroy', loggedOutunbined);
+    $scope.$on('$destroy', onDestroy);
 
   }]);

--- a/web-client/app/scripts/controllers/newArticleController.js
+++ b/web-client/app/scripts/controllers/newArticleController.js
@@ -1,0 +1,27 @@
+'use strict';
+
+angular.module('webClientApp')
+  .controller('NewArticleCtrl', ['$rootScope', '$scope', '$routeParams', '$location', '$analytics', '$window', 'Article',
+      function ($rootScope, $scope, $routeParams, $location, $analytics, $window, Article) {
+
+    var createSuccess = function (resource) {
+      $scope.inProgress = null;
+      $analytics.eventTrack('Article Created', {
+        category: 'Article',
+        label: resource.title
+      });
+      $location.path('/articles/' + resource.id + '/edit');
+    };
+
+    var createError = function (response) {
+      $scope.inProgress = null;
+      $analytics.eventTrack('Article Create Error', {
+        category: 'Article',
+        label: angular.toJson(response.errors)
+      });
+      $scope.error = 'حدث خطأ في حفظ المقال.';
+    };
+
+    Article.save({ article: { published: false } }, createSuccess, createError);
+
+  }]);

--- a/web-client/app/styles/main.scss
+++ b/web-client/app/styles/main.scss
@@ -766,6 +766,12 @@ ul.manshar-articles-list {
   -webkit-backface-visibility:hidden; /* Chrome and Safari */
   -moz-backface-visibility:hidden; /* Firefox */
   -ms-backface-visibility:hidden; /* Internet Explorer 10+ */
+
+  .status {
+    font-size: .6em;
+    color: #666;
+    margin-left: 1em;
+  }
 }
 
 button {

--- a/web-client/app/views/articles/edit.html
+++ b/web-client/app/views/articles/edit.html
@@ -62,14 +62,17 @@
 
 <div class="metabar tray">
   <div class="manshar-controls">
+    <span class="status" ng-show="!isSaving">
+      محفوظ كمسودة
+    </span>
+    <span class="status" ng-show="isSaving">
+      يتم حفظ المقال...
+    </span>
     <button class="action-button" ng-click="saveArticle(article, true)" ng-disabled="inProgress" ng-class="{'in-progress': inProgress == 'publish'}">
       <i>نشر</i>
     </button>
-    <button class="action-button" ng-click="saveArticle(article, false)" ng-disabled="inProgress" ng-class="{'in-progress': inProgress == 'save'}">
-      <i class="fa fa-floppy-o"></i>
-    </button>
     <button class="action-button" ng-click="deleteArticle(article)" ng-if="article.id" ng-disabled="inProgress" ng-class="{'in-progress': inProgress == 'delete'}">
-      <i class="fa fa-times"></i>
+      <i class="fa fa-trash-o"></i>
     </button>
     <button class="action-button" ng-click="cancel()" ng-disabled="inProgress" ng-class="{'in-progress': inProgress == 'cancel'}">
       <i class="fa fa-arrow-left"></i>

--- a/web-client/app/views/profiles/show.html
+++ b/web-client/app/views/profiles/show.html
@@ -65,7 +65,7 @@
         </div>
         <div class="profile-article-action">
           <button class="action-button" ng-click="deleteArticle(article)" ng-if="article.id" ng-disabled="inProgress" ng-class="{'in-progress': inProgress == 'delete'}">
-            <i class="fa fa-times"></i>
+            <i class="fa fa-trash-o"></i>
           </button>
           <button class="action-button" ng-click="editArticle(article.id)" ng-show="isOwner(currentUser, article)">
             <i class="fa fa-pencil"></i>

--- a/web-client/test/spec/controllers/editArticleController.js
+++ b/web-client/test/spec/controllers/editArticleController.js
@@ -82,11 +82,6 @@ describe('Controller: EditArticleCtrl', function () {
   });
 
   it('should listen to logged out event and unbind it when destroied', function () {
-    // New Article.
-    createController();
-    rootScope.$emit('user.loggedOut');
-    expect(location.path()).toBe('/');
-
     // Edit Article.
     spyOn(scope, '$on').andCallFake(function (event) {
       expect(event).toBe('$destroy');
@@ -110,7 +105,7 @@ describe('Controller: EditArticleCtrl', function () {
       httpBackend.flush();
 
       spyOn(ArticleModel, 'update').andCallFake(function(params, data, success) {
-        success({id: 2});
+        success({id: 2, published: true});
       });
       scope.saveArticle(scope.article);
       expect(ArticleModel.update).toHaveBeenCalled();
@@ -119,21 +114,11 @@ describe('Controller: EditArticleCtrl', function () {
 
     it('should set error on scope', function () {
       createController();
-      spyOn(ArticleModel, 'save').andCallFake(function(data, success, error) {
+      spyOn(ArticleModel, 'update').andCallFake(function(params, data, success, error) {
         error({});
       });
       scope.saveArticle(scope.article);
       expect(scope.error).toBe('حدث خطأ في حفظ المقال.');
-    });
-
-    it('should create a new article using Article.save', function () {
-      createController();
-      spyOn(ArticleModel, 'save').andCallFake(function(data, success) {
-        success({id: 2});
-      });
-      scope.saveArticle(scope.article);
-      expect(ArticleModel.save).toHaveBeenCalled();
-      expect(location.path()).toBe('/articles/2');
     });
   });
 
@@ -182,19 +167,17 @@ describe('Controller: EditArticleCtrl', function () {
       httpBackend.flush();
       spyOn(mock, 'confirm').andCallFake(function() {return true;});
       scope.cancel();
-      expect(mock.confirm).toHaveBeenCalled();
+      expect(mock.confirm).not.toHaveBeenCalled();
       expect(location.path()).toBe('/');
-    });
 
-    it('should not cancel if the user did not confirm', function () {
-      httpBackend.expectGET(apiBase + 'articles/1').respond({id: 1, title: 'Hello World.'});
+      httpBackend.expectGET(apiBase + 'articles/1').respond({title: 'Hello World.'});
       routeParams.articleId = 1;
       createController();
       httpBackend.flush();
-      spyOn(mock, 'confirm').andCallFake(function() {return false;});
+      scope.article.title = 'Bye World.';
       scope.cancel();
       expect(mock.confirm).toHaveBeenCalled();
-      expect(location.path()).toBe('/articles/1');
+      expect(location.path()).toBe('/');
     });
 
     it('should not confirm before canceling unchanged new article', function () {


### PR DESCRIPTION
This is one of our top requested feature and one of the biggest frustration the users are facing when they mistakenly close the tab or navigate away from the page! This changes two things:
- Clicking Create will initialize and store an empty article and the user will update that article afterwards.
- When a user wants to update an already published article, they will be warned that the article will be moved to draft and they can publish it again once done.
- Dropped the save button.
