### PR TITLE
Fix performance issues due to not cleaning up event binding in anchoredComment related directives.

### DIFF
--- a/web-client/app/scripts/directives/anchoredComment.js
+++ b/web-client/app/scripts/directives/anchoredComment.js
@@ -31,6 +31,18 @@ angular.module('webClientApp')
       }
     };
 
+    var listeners = [];
+    /**
+     * Cleans up event listeners we added on $rootScope when the directive
+     * is destroyed.
+     */
+    var cleanup = function() {
+      for (var i = 0; i < listeners.length; i++) {
+        listeners[i]();
+      }
+      listeners = [];
+    };
+
     return {
       templateUrl: '/views/directives/anchoredComment.html',
       restrict: 'A',
@@ -41,11 +53,12 @@ angular.module('webClientApp')
         scope.commentsCount = 0;
 
         // Shows the anchor icon for the user to click.
-        $rootScope.$on('show-anchor', function(e, data) {
+        var listener = $rootScope.$on('show-anchor', function(e, data) {
           $timeout(function() {
             scope.isActive = (data === scope.guid);
           });
         });
+        listeners.push(listener);
 
         // On clicking the bubble icon send an event to show the comment.
         var commentButton = element.find('div').find('i');
@@ -56,6 +69,10 @@ angular.module('webClientApp')
 
           $rootScope.$broadcast(
               'show-comment', {target: clickedEl, guid: scope.guid});
+        });
+        // Make sure to unbind events we binded to elements.
+        commentButton.on('$destroy', function() {
+          commentButton.off('click');
         });
 
         scope.$watch('$parent.comments', function(newValue) {
@@ -72,6 +89,7 @@ angular.module('webClientApp')
           }
         }, true);
 
+        scope.$on('$destroy', cleanup);
       }
     };
   }]);

--- a/web-client/app/scripts/directives/anchoredComments.js
+++ b/web-client/app/scripts/directives/anchoredComments.js
@@ -57,6 +57,10 @@ angular.module('webClientApp')
 
       // Adding click and mouseover listeners to show anchor bubbles.
       angular.element(srcElement).on('click mouseover', showAnchor);
+      // Make sure to unbind events we binded to elements.
+      angular.element(srcElement).on('$destroy', function() {
+        angular.element(srcElement).off('click mouseover');
+      });
     };
 
     /**
@@ -83,6 +87,18 @@ angular.module('webClientApp')
       if (el) {
         angular.element(el).removeClass(COMMENT_HIGHLIGHT_CLASS);
       }
+    };
+
+    var listeners = [];
+    /**
+     * Cleans up event listeners we added on $rootScope when the directive
+     * is destroyed.
+     */
+    var cleanup = function() {
+      for (var i = 0; i < listeners.length; i++) {
+        listeners[i]();
+      }
+      listeners = [];
     };
 
     return {
@@ -135,7 +151,7 @@ angular.module('webClientApp')
         });
 
         // Listen to 'show-comment' event and activate the choosen comment.
-        $rootScope.$on('show-comment', function(e, data) {
+        var listener = $rootScope.$on('show-comment', function(e, data) {
           $timeout(function() {
             clearHighlightedComment();
 
@@ -152,6 +168,9 @@ angular.module('webClientApp')
             }, 50);
           });
         });
+        listeners.push(listener);
+
+        scope.$on('$destroy', cleanup);
 
         /**
          * On clicking outside the main comment box hide the sidebar.


### PR DESCRIPTION
This caused users who browse the site and jump from an article to the next and so on to see sluggish scrolling and slow performance and high CPU usage because we weren't cleaning up the events we binded to elements in anchorComment and anchorComments directive.
