### PR TITLE
Add mailboxer and notify users about new comments and recommendations goals

### DIFF
--- a/backend/Gemfile
+++ b/backend/Gemfile
@@ -32,6 +32,8 @@ gem 'oj'
 # And it is to get around installing sass on Travis.
 gem 'sass'
 
+# Used to manage notifications, emails and messaging.
+gem 'mailboxer', git: 'https://github.com/ging/mailboxer.git'
 
 group :production do
   gem 'rails_12factor'

--- a/backend/Gemfile.lock
+++ b/backend/Gemfile.lock
@@ -1,3 +1,12 @@
+GIT
+  remote: https://github.com/ging/mailboxer.git
+  revision: cde8b2847a5600256c8aa161f68e22c34603ef8b
+  specs:
+    mailboxer (0.12.4)
+      carrierwave (>= 0.5.8)
+      foreigner (>= 0.9.1)
+      rails (>= 3.2.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -30,6 +39,11 @@ GEM
     atomic (1.1.14)
     bcrypt-ruby (3.1.2)
     builder (3.1.4)
+    carrierwave (0.10.0)
+      activemodel (>= 3.2.0)
+      activesupport (>= 3.2.0)
+      json (>= 1.7)
+      mime-types (>= 1.16)
     celluloid (0.15.2)
       timers (~> 1.1.0)
     coderay (1.1.0)
@@ -70,6 +84,8 @@ GEM
       net-ssh (>= 2.1.3)
       nokogiri (~> 1.5)
       ruby-hmac
+    foreigner (1.7.1)
+      activerecord (>= 3.0.0)
     foreman (0.63.0)
       dotenv (>= 0.7)
       thor (>= 0.13.6)
@@ -85,6 +101,7 @@ GEM
       rspec (~> 2.14)
     hike (1.2.3)
     i18n (0.6.9)
+    json (1.8.1)
     launchy (2.4.3)
       addressable (~> 2.3)
     listen (2.2.0)
@@ -202,6 +219,7 @@ DEPENDENCIES
   factory_girl_rails
   foreman
   guard-rspec
+  mailboxer!
   oj
   pg
   puma

--- a/backend/app/models/comment.rb
+++ b/backend/app/models/comment.rb
@@ -1,4 +1,39 @@
+#!/bin/env ruby
+# encoding: utf-8
+
 class Comment < ActiveRecord::Base
   belongs_to :user, :counter_cache => true
   belongs_to :article, :counter_cache => true
+
+  has_many :notifications, -> { where notified_object_type: 'Comment'},
+      foreign_key: :notified_object_id
+
+  after_commit :create_notification, on: :create
+
+  # TODO(mkhatib): Link to the specific location of the comment and handle it
+  # on the webclient to open the drawer on that comment and highlight it.
+  def create_notification
+    host = ENV['WEB_CLIENT_HOST']
+    url = "http://#{host}/articles/#{article.id}"
+
+    # Notify the article author of the new comment
+    subject = "#{user.name} علق على مقالك '#{article.title}'"
+    body = "#{user.name} ترك تعليق على مقالك <a href='#{url}' target='blank'>'#{article.title}'</a>. التعليق هو:\n#{body}\n"
+    if not user.id.equal? article.user.id
+      article.user.notify(subject, body, self)
+    end
+
+    # Notify any users who have commented on the same section (i.e. guid).
+    past_commenters = Comment.where(
+        guid: guid).includes(:user).collect(&:user).uniq
+    body = "#{user.name} ترك تعليق على مقالك <a href='#{url}' target='blank'>'#{article.title}'</a> بعد تعليقك. التعليق هو:\n#{body}\n"
+    past_commenters.each do |commenter|
+      # Don't notify the owner of the article they already have been notified.
+      if not commenter.id.equal? article.user.id
+        commenter.notify(subject, body, self)
+      end
+    end
+
+  end
+
 end

--- a/backend/app/models/recommendation.rb
+++ b/backend/app/models/recommendation.rb
@@ -1,6 +1,36 @@
+#!/bin/env ruby
+# encoding: utf-8
+
 class Recommendation < ActiveRecord::Base
   belongs_to :user, :counter_cache => true
   belongs_to :article, :counter_cache => true
 
   validates_uniqueness_of :user_id, :scope => :article_id
+
+  has_many :notifications, -> { where notified_object_type: 'Recommendation'},
+      foreign_key: :notified_object_id
+
+  after_commit :maybe_create_notification, on: :create
+
+  private
+
+  # Only notify the user when they get 5, 10, 15, 20... recommendations.
+  def should_notify?
+    (article.recommendations_count > 0 and
+     article.recommendations_count.modulo(5) == 0)
+  end
+
+  def maybe_create_notification
+    # TODO(mkhatib): If someone likes and dislikes and likes again consequently
+    # we'll send many emails. We need to catch this and make sure not to spam
+    # the user.
+    if should_notify?
+      host = ENV['WEB_CLIENT_HOST']
+      url = "http://#{host}/articles/#{article.id}"
+      subject = "#{article.recommendations_count} توصيات على مقالك '#{article.title}'"
+      body = "وصل مقالك <a href='#{url}' target='blank'>'#{article.title}'</a> ل #{article.recommendations_count} توصيات."
+      article.user.notify(subject, body, self)
+    end
+  end
+
 end

--- a/backend/app/models/user.rb
+++ b/backend/app/models/user.rb
@@ -1,6 +1,8 @@
 class User < ActiveRecord::Base
   include Utils
 
+  acts_as_messageable
+
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :trackable, :validatable,
          :token_authenticatable, :confirmable
@@ -32,5 +34,9 @@ class User < ActiveRecord::Base
     else
       abs_url avatar.url, ENV['API_HOST']
     end
+  end
+
+  def mailboxer_email(object)
+    email
   end
 end

--- a/backend/app/views/mailboxer/message_mailer/new_message_email.html.erb
+++ b/backend/app/views/mailboxer/message_mailer/new_message_email.html.erb
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta content="text/html; charset=UTF-8" http-equiv="Content-Type" />
+  </head>
+  <body>
+    <h1>You have a new message: <%= @subject %></h1>
+    <p>
+      You have received a new message:
+    </p>
+    <blockquote>
+      <p>
+        <%= raw @message.body %>
+      </p>
+    </blockquote>
+    <p>
+      Visit <%= link_to root_url, root_url %> and go to your inbox for more info.
+    </p>
+  </body>
+</html>

--- a/backend/app/views/mailboxer/message_mailer/new_message_email.text.erb
+++ b/backend/app/views/mailboxer/message_mailer/new_message_email.text.erb
@@ -1,0 +1,10 @@
+You have a new message: <%= @subject %>
+===============================================
+
+You have received a new message:
+
+-----------------------------------------------
+<%= @message.body.html_safe? ? @message.body : strip_tags(@message.body) %>
+-----------------------------------------------
+
+Visit <%= root_url %> and go to your inbox for more info.

--- a/backend/app/views/mailboxer/message_mailer/reply_message_email.html.erb
+++ b/backend/app/views/mailboxer/message_mailer/reply_message_email.html.erb
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta content="text/html; charset=UTF-8" http-equiv="Content-Type" />
+  </head>
+  <body>
+    <h1>You have a new reply: <%= @subject %></h1>
+    <p>
+      You have received a new reply:
+    </p>
+    <blockquote>
+      <p>
+        <%= raw @message.body %>
+      </p>
+    </blockquote>
+    <p>
+      Visit <%= link_to root_url, root_url %> and go to your inbox for more info.
+    </p>
+  </body>
+</html>

--- a/backend/app/views/mailboxer/message_mailer/reply_message_email.text.erb
+++ b/backend/app/views/mailboxer/message_mailer/reply_message_email.text.erb
@@ -1,0 +1,10 @@
+You have a new reply: <%= @subject %>
+===============================================
+
+You have received a new reply:
+
+-----------------------------------------------
+<%= @message.body.html_safe? ? @message.body : strip_tags(@message.body) %>
+-----------------------------------------------
+
+Visit <%= root_url %> and go to your inbox for more info.

--- a/backend/app/views/mailboxer/notification_mailer/new_notification_email.html.erb
+++ b/backend/app/views/mailboxer/notification_mailer/new_notification_email.html.erb
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta content="text/html; charset=UTF-8" http-equiv="Content-Type" />
+  </head>
+  <body dir="rtl">
+    <h1>
+      لديك تنبيه جديد على منشر:
+      <%= @notification.subject.html_safe? ? @notification.subject : strip_tags(@notification.subject) %>
+    </h1>
+    <blockquote>
+      <p>
+        <%= raw @notification.body %>
+      </p>
+    </blockquote>
+    <p>
+      قم بزيارة
+      <a href="http://<%=ENV['WEB_CLIENT_HOST']%>">
+        منشر
+      </a>
+    </p>
+  </body>
+</html>

--- a/backend/app/views/mailboxer/notification_mailer/new_notification_email.text.erb
+++ b/backend/app/views/mailboxer/notification_mailer/new_notification_email.text.erb
@@ -1,0 +1,10 @@
+لديك تنبيه جديد على منشر: <%= @notification.subject.html_safe? ? @notification.subject : strip_tags(@notification.subject) %>
+===============================================
+
+-----------------------------------------------
+<%= @notification.body.html_safe? ? @notification.body : strip_tags(@notification.body) %>
+-----------------------------------------------
+
+قم بزيارة
+http://<%=ENV['WEB_CLIENT_HOST']%>
+  منشر

--- a/backend/config/initializers/mailboxer.rb
+++ b/backend/config/initializers/mailboxer.rb
@@ -1,0 +1,21 @@
+Mailboxer.setup do |config|
+
+  #Configures if you application uses or not email sending for Notifications and Messages
+  config.uses_emails = true
+
+  #Configures the default from for emails sent for Messages and Notifications
+  config.default_from = "noreply@manshar.com"
+
+  #Configures the methods needed by mailboxer
+  config.email_method = :mailboxer_email
+  config.name_method = :name
+
+  #Configures if you use or not a search engine and which one you are using
+  #Supported engines: [:solr,:sphinx]
+  config.search_enabled = false
+  config.search_engine = :solr
+
+  #Configures maximum length of the message subject and body
+  config.subject_max_length = 255
+  config.body_max_length = 32000
+end

--- a/backend/db/migrate/20150101001902_create_mailboxer.mailboxer_engine.rb
+++ b/backend/db/migrate/20150101001902_create_mailboxer.mailboxer_engine.rb
@@ -1,0 +1,66 @@
+# This migration comes from mailboxer_engine (originally 20110511145103)
+class CreateMailboxer < ActiveRecord::Migration
+  def self.up    
+  #Tables
+  	#Conversations
+    create_table :mailboxer_conversations do |t|
+      t.column :subject, :string, :default => ""
+      t.column :created_at, :datetime, :null => false
+      t.column :updated_at, :datetime, :null => false
+    end    
+  	#Receipts
+    create_table :mailboxer_receipts do |t|
+      t.references :receiver, :polymorphic => true
+      t.column :notification_id, :integer, :null => false
+      t.column :is_read, :boolean, :default => false
+      t.column :trashed, :boolean, :default => false
+      t.column :deleted, :boolean, :default => false
+      t.column :mailbox_type, :string, :limit => 25
+      t.column :created_at, :datetime, :null => false
+      t.column :updated_at, :datetime, :null => false
+    end    
+  	#Notifications and Messages
+    create_table :mailboxer_notifications do |t|
+      t.column :type, :string
+      t.column :body, :text
+      t.column :subject, :string, :default => ""
+      t.references :sender, :polymorphic => true
+      t.column :conversation_id, :integer
+      t.column :draft, :boolean, :default => false
+      t.string :notification_code, :default => nil
+      t.references :notified_object, :polymorphic => true
+      t.column :attachment, :string
+      t.column :updated_at, :datetime, :null => false
+      t.column :created_at, :datetime, :null => false
+      t.boolean :global, default: false
+      t.datetime :expires
+    end    
+    
+    
+  #Indexes
+  	#Conversations
+  	#Receipts
+  	add_index "mailboxer_receipts","notification_id"
+
+  	#Messages  
+  	add_index "mailboxer_notifications","conversation_id"
+  
+  #Foreign keys    
+  	#Conversations
+  	#Receipts
+  	add_foreign_key "mailboxer_receipts", "mailboxer_notifications", :name => "receipts_on_notification_id", :column => "notification_id"
+  	#Messages  
+  	add_foreign_key "mailboxer_notifications", "mailboxer_conversations", :name => "notifications_on_conversation_id", :column => "conversation_id"
+  end
+  
+  def self.down
+  #Tables  	
+  	remove_foreign_key "mailboxer_receipts", :name => "receipts_on_notification_id"
+  	remove_foreign_key "mailboxer_notifications", :name => "notifications_on_conversation_id"
+  	
+  #Indexes
+    drop_table :mailboxer_receipts
+    drop_table :mailboxer_conversations
+    drop_table :mailboxer_notifications
+  end
+end

--- a/backend/db/migrate/20150101001903_add_conversation_optout.mailboxer_engine.rb
+++ b/backend/db/migrate/20150101001903_add_conversation_optout.mailboxer_engine.rb
@@ -1,0 +1,15 @@
+# This migration comes from mailboxer_engine (originally 20131206080416)
+class AddConversationOptout < ActiveRecord::Migration
+  def self.up
+    create_table :mailboxer_conversation_opt_outs do |t|
+      t.references :unsubscriber, :polymorphic => true
+      t.references :conversation
+    end
+    add_foreign_key "mailboxer_conversation_opt_outs", "mailboxer_conversations", :name => "mb_opt_outs_on_conversations_id", :column => "conversation_id"
+  end
+
+  def self.down
+    remove_foreign_key "mailboxer_conversation_opt_outs", :name => "mb_opt_outs_on_conversations_id"
+    drop_table :mailboxer_conversation_opt_outs
+  end
+end

--- a/backend/db/migrate/20150101001904_add_missing_indices.mailboxer_engine.rb
+++ b/backend/db/migrate/20150101001904_add_missing_indices.mailboxer_engine.rb
@@ -1,0 +1,20 @@
+# This migration comes from mailboxer_engine (originally 20131206080417)
+class AddMissingIndices < ActiveRecord::Migration
+  def change
+    # We'll explicitly specify its name, as the auto-generated name is too long and exceeds 63
+    # characters limitation.
+    add_index :mailboxer_conversation_opt_outs, [:unsubscriber_id, :unsubscriber_type],
+      name: 'index_mailboxer_conversation_opt_outs_on_unsubscriber_id_type'
+    add_index :mailboxer_conversation_opt_outs, :conversation_id
+
+    add_index :mailboxer_notifications, :type
+    add_index :mailboxer_notifications, [:sender_id, :sender_type]
+
+    # We'll explicitly specify its name, as the auto-generated name is too long and exceeds 63
+    # characters limitation.
+    add_index :mailboxer_notifications, [:notified_object_id, :notified_object_type],
+      name: 'index_mailboxer_notifications_on_notified_object_id_and_type'
+
+    add_index :mailboxer_receipts, [:receiver_id, :receiver_type]
+  end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20141205063002) do
+ActiveRecord::Schema.define(version: 20150101001904) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -48,6 +48,59 @@ ActiveRecord::Schema.define(version: 20141205063002) do
     t.datetime "created_at"
     t.datetime "updated_at"
   end
+
+  create_table "mailboxer_conversation_opt_outs", force: true do |t|
+    t.integer "unsubscriber_id"
+    t.string  "unsubscriber_type"
+    t.integer "conversation_id"
+  end
+
+  add_index "mailboxer_conversation_opt_outs", ["conversation_id"], name: "index_mailboxer_conversation_opt_outs_on_conversation_id", using: :btree
+  add_index "mailboxer_conversation_opt_outs", ["unsubscriber_id", "unsubscriber_type"], name: "index_mailboxer_conversation_opt_outs_on_unsubscriber_id_type", using: :btree
+
+  create_table "mailboxer_conversations", force: true do |t|
+    t.string   "subject",    default: ""
+    t.datetime "created_at",              null: false
+    t.datetime "updated_at",              null: false
+  end
+
+  create_table "mailboxer_notifications", force: true do |t|
+    t.string   "type"
+    t.text     "body"
+    t.string   "subject",              default: ""
+    t.integer  "sender_id"
+    t.string   "sender_type"
+    t.integer  "conversation_id"
+    t.boolean  "draft",                default: false
+    t.string   "notification_code"
+    t.integer  "notified_object_id"
+    t.string   "notified_object_type"
+    t.string   "attachment"
+    t.datetime "updated_at",                           null: false
+    t.datetime "created_at",                           null: false
+    t.boolean  "global",               default: false
+    t.datetime "expires"
+  end
+
+  add_index "mailboxer_notifications", ["conversation_id"], name: "index_mailboxer_notifications_on_conversation_id", using: :btree
+  add_index "mailboxer_notifications", ["notified_object_id", "notified_object_type"], name: "index_mailboxer_notifications_on_notified_object_id_and_type", using: :btree
+  add_index "mailboxer_notifications", ["sender_id", "sender_type"], name: "index_mailboxer_notifications_on_sender_id_and_sender_type", using: :btree
+  add_index "mailboxer_notifications", ["type"], name: "index_mailboxer_notifications_on_type", using: :btree
+
+  create_table "mailboxer_receipts", force: true do |t|
+    t.integer  "receiver_id"
+    t.string   "receiver_type"
+    t.integer  "notification_id",                            null: false
+    t.boolean  "is_read",                    default: false
+    t.boolean  "trashed",                    default: false
+    t.boolean  "deleted",                    default: false
+    t.string   "mailbox_type",    limit: 25
+    t.datetime "created_at",                                 null: false
+    t.datetime "updated_at",                                 null: false
+  end
+
+  add_index "mailboxer_receipts", ["notification_id"], name: "index_mailboxer_receipts_on_notification_id", using: :btree
+  add_index "mailboxer_receipts", ["receiver_id", "receiver_type"], name: "index_mailboxer_receipts_on_receiver_id_and_receiver_type", using: :btree
 
   create_table "recommendations", force: true do |t|
     t.integer  "article_id"
@@ -95,5 +148,11 @@ ActiveRecord::Schema.define(version: 20141205063002) do
   add_index "users", ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true, using: :btree
   add_index "users", ["email"], name: "index_users_on_email", unique: true, using: :btree
   add_index "users", ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, using: :btree
+
+  add_foreign_key "mailboxer_conversation_opt_outs", "mailboxer_conversations", name: "mb_opt_outs_on_conversations_id", column: "conversation_id"
+
+  add_foreign_key "mailboxer_notifications", "mailboxer_conversations", name: "notifications_on_conversation_id", column: "conversation_id"
+
+  add_foreign_key "mailboxer_receipts", "mailboxer_notifications", name: "receipts_on_notification_id", column: "notification_id"
 
 end


### PR DESCRIPTION
This adds mailboxer to Manshar and set the notifications to be sent by emails on three occasions:
  - Notify article author about new comments.
  - Notify users who commented on the same paragraph on new comments (i.e. replies) to their comments.
  - Notify article author about reaching recommendation count goals (currently multiples of 5).