### PR TITLE
Add role to User model. Allow comments and article owner to delete comments

### DIFF
--- a/backend/app/models/user.rb
+++ b/backend/app/models/user.rb
@@ -28,6 +28,14 @@ class User < ActiveRecord::Base
     articles.drafts.recents
   end
 
+  def admin
+    role == 'admin'
+  end
+
+  def staff
+    role == 'staff'
+  end
+
   def avatar_abs_url size = nil
     if size
       abs_url avatar.thumb(size).url, ENV['API_HOST']

--- a/backend/app/policies/comment_policy.rb
+++ b/backend/app/policies/comment_policy.rb
@@ -29,13 +29,17 @@ class CommentPolicy < ApplicationPolicy
   end
 
   def destroy?
-    super || owned?
+    super || owned? || article_owner?
   end
 
 
   private
   def owned?
     comment.user_id == user.id if user
+  end
+
+  def article_owner?
+    comment.article.user_id == user.id if user
   end
 
 end

--- a/backend/app/views/api/v1/users/show.rabl
+++ b/backend/app/views/api/v1/users/show.rabl
@@ -1,6 +1,6 @@
 object @user
 
-attributes :id, :name, :bio, :created_at
+attributes :id, :name, :bio, :created_at, :admin, :staff
 
 # Don't return cover for listings. We only need these when we are getting the
 # full article. This might change in the future but for now this is causing

--- a/backend/db/migrate/20150103005507_add_role_to_users.rb
+++ b/backend/db/migrate/20150103005507_add_role_to_users.rb
@@ -1,0 +1,5 @@
+class AddRoleToUsers < ActiveRecord::Migration
+  def change
+    add_column :users, :role, :string, :default => 'user'
+  end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150101001904) do
+ActiveRecord::Schema.define(version: 20150103005507) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -119,12 +119,12 @@ ActiveRecord::Schema.define(version: 20150101001904) do
   end
 
   create_table "users", force: true do |t|
-    t.string   "email",                  default: "", null: false
-    t.string   "encrypted_password",     default: "", null: false
+    t.string   "email",                  default: "",     null: false
+    t.string   "encrypted_password",     default: "",     null: false
     t.string   "reset_password_token"
     t.datetime "reset_password_sent_at"
     t.datetime "remember_created_at"
-    t.integer  "sign_in_count",          default: 0,  null: false
+    t.integer  "sign_in_count",          default: 0,      null: false
     t.datetime "current_sign_in_at"
     t.datetime "last_sign_in_at"
     t.string   "current_sign_in_ip"
@@ -136,12 +136,13 @@ ActiveRecord::Schema.define(version: 20150101001904) do
     t.string   "authentication_token"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "name",                   default: "", null: false
+    t.string   "name",                   default: "",     null: false
     t.string   "bio",                    default: ""
-    t.string   "avatar_uid",                          null: false
+    t.string   "avatar_uid",                              null: false
     t.string   "avatar_name"
     t.integer  "recommendations_count",  default: 0
     t.integer  "comments_count",         default: 0
+    t.string   "role",                   default: "user"
   end
 
   add_index "users", ["authentication_token"], name: "index_users_on_authentication_token", unique: true, using: :btree

--- a/web-client/app/scripts/directives/anchoredComments.js
+++ b/web-client/app/scripts/directives/anchoredComments.js
@@ -15,8 +15,8 @@ angular.module('webClientApp')
    * @param  {ArticleComment} ArticleComment Manshar's article comments service.
    * @return {!angular.Directive} Angular directive description.
    */
-  .directive('anchoredComments', ['$rootScope', '$compile', '$timeout', 'ArticleComment',
-      function ($rootScope, $compile, $timeout, ArticleComment) {
+  .directive('anchoredComments', ['$rootScope', '$compile', '$timeout', '$window', 'ArticleComment',
+      function ($rootScope, $compile, $timeout, $window, ArticleComment) {
 
     var COMMENT_HIGHLIGHT_CLASS = 'comment-highlighted';
     var ANCHORS_ACTIVE = 'anchored-comments-active';
@@ -213,6 +213,23 @@ angular.module('webClientApp')
 
             e.preventDefault();
           }
+        };
+
+        /**
+         * Deletes a comment on an article.
+         * @param {Object} comment The comment object to delete.
+         */
+        scope.deleteComment = function(comment) {
+          ArticleComment.delete({
+            'articleId': scope.article.id,
+            'commentId': comment.id
+          }, function () {
+            var index = scope.comments.indexOf(comment);
+            scope.comments.splice(index, 1);
+          }, function (error) {
+            $window.alert('حدث خطأ ما. الرجاء المحاولة مجدداً');
+            console.log(error);
+          });
         };
 
       }

--- a/web-client/app/styles/main.scss
+++ b/web-client/app/styles/main.scss
@@ -181,6 +181,10 @@ input[type="password"] {
           left: 2em;
         }
 
+        .actions {
+          text-align: left;
+        }
+
       }
     }
 

--- a/web-client/app/views/directives/anchoredComments.html
+++ b/web-client/app/views/directives/anchoredComments.html
@@ -25,6 +25,12 @@
       <span class="date">
         {{comment.created_at | date:'EEEE, d MMMM'}}
       </span>
+      <div class="actions">
+        <a class="delete-button" ng-click="deleteComment(comment)"
+            ng-show="$root.isOwner(currentUser, comment) || $root.isOwner(currentUser, article)">
+          <i class="fa fa-trash-o"></i>
+        </a>
+      </div>
     </li>
   </ul>
 </div>


### PR DESCRIPTION
role attribute is to used to promote users to admins or staff for future features to enable admin control or promoting articles to staff-picked.

Users can now delete their own comments as well as comments made by others on their articles.