### PR TITLE
Improve the performance of comments anchors rendering 

### DIFF
--- a/web-client/app/scripts/directives/anchoredComment.js
+++ b/web-client/app/scripts/directives/anchoredComment.js
@@ -61,13 +61,13 @@ angular.module('webClientApp')
         listeners.push(listener);
 
         // On clicking the bubble icon send an event to show the comment.
-        var commentButton = element.find('div').find('i');
+        var commentButton = element.find('div').find('span');
         commentButton.on('click', function(e) {
           // Get the clicked anchor.
           var clickedEl = getParentWithClassName(
               'anchored-comment-box', e.target);
 
-          $rootScope.$broadcast(
+          $rootScope.$emit(
               'show-comment', {target: clickedEl, guid: scope.guid});
         });
         // Make sure to unbind events we binded to elements.
@@ -75,11 +75,10 @@ angular.module('webClientApp')
           commentButton.off('click');
         });
 
-        scope.$watch('$parent.comments', function(newValue) {
-          if (!newValue) {
-            return;
-          }
-
+        // All we care about here is the length of the array to update
+        // the counts of the comments on each anchor.
+        scope.$watch('$parent.comments.length', function() {
+          scope.commentsCount = 0;
           // Calculate how many comments this GUID have.
           var comments = scope.$parent.comments;
           for (var i = 0; i < comments.length; i++) {
@@ -87,7 +86,7 @@ angular.module('webClientApp')
               scope.commentsCount++;
             }
           }
-        }, true);
+        });
 
         scope.$on('$destroy', cleanup);
       }

--- a/web-client/app/scripts/directives/anchoredComments.js
+++ b/web-client/app/scripts/directives/anchoredComments.js
@@ -43,7 +43,7 @@ angular.module('webClientApp')
       // their parent guids.
       var guidElement = getAncestorWithGuid(e.target);
       var guid = guidElement.getAttribute('data-guid');
-      $rootScope.$broadcast('show-anchor', guid);
+      $rootScope.$emit('show-anchor', guid);
     };
 
     /**
@@ -137,28 +137,35 @@ angular.module('webClientApp')
             return;
           }
 
-          // When images get loaded in the guid elements container we need
-          // to reposition the comments to calculate for hte images hieght.
-          var guidContainer = document.getElementById(
-              scope.guidElementsContainerId);
-          angular.element(guidContainer).find('img').on('load', function() {
-            repositionComments(element[0]);
-          });
+          // Need to render the anchors after making sure the page has
+          // rendered fully.
+          $timeout(function() {
+
+            // When images get loaded in the guid elements container we need
+            // to reposition the comments to calculate for hte images hieght.
+            var guidContainer = document.getElementById(
+                scope.guidElementsContainerId);
+            angular.element(guidContainer).find('img').on('load', function() {
+              repositionComments(element[0]);
+            });
 
 
-          // Get all comments for this article.
-          ArticleComment.query({
-            'articleId': scope.article.id
-          }, function(comments) {
-            scope.comments = comments;
-          });
+            // Get all comments for this article.
+            ArticleComment.query({
+              'articleId': scope.article.id
+            }, function(comments) {
+              scope.comments = comments;
+            });
 
-          // Loop over all elements with the GUID class.
-          var elements = document.getElementsByClassName(
-              scope.guidElementsClass);
-          for (var i = 0; i < elements.length; i++) {
-            createNewComment(elements[i], scope, element[0]);
-          }
+            // Loop over all elements with the GUID class.
+            var elements = document.getElementsByClassName(
+                scope.guidElementsClass);
+            for (var i = 0; i < elements.length; i++) {
+              createNewComment(elements[i], scope, element[0]);
+            }
+
+          }, 200);
+
         });
 
         // Listen to 'show-comment' event and activate the choosen comment.

--- a/web-client/app/styles/enhanced.scss
+++ b/web-client/app/styles/enhanced.scss
@@ -113,10 +113,16 @@ body {
     left: 0;
 
     .anchored-comment-box {
-      i {
-        font-size: 1.5em;
+      .icon-count-container {
+        i {
+          font-size: 1.5em;
+        }
+        span {
+          top: -3px;
+          color: #fff;
+          font-size: .9em;
+        }
       }
-
     }
   }
 

--- a/web-client/app/styles/main.scss
+++ b/web-client/app/styles/main.scss
@@ -250,16 +250,33 @@ button {
   .anchored-comment-box {
     position: absolute;
 
-    i {
-      font-size: 1em;
-      color: #c0c0c0;
-      transform: scaleX(-1);
+    .icon-count-container {
+
+      position: relative;
+      cursor: pointer;
 
       &:hover {
-        color: #000;
+        i {
+          color: #000;
+        }
+      }
+
+      i {
+        font-size: 1em;
+        color: #909090;
+        transform: scaleX(-1);
+      }
+      span {
+        position: absolute;
+        top: 2px;
+        right: 0;
+        left: 0;
+        text-align: center;
+        color: #fff;
+        font-size: 0.7em;
+        cursor: pointer;
       }
     }
-
   }
 }
 

--- a/web-client/app/views/directives/anchoredComment.html
+++ b/web-client/app/views/directives/anchoredComment.html
@@ -1,3 +1,6 @@
 <div class="anchored-comment-box" ng-show="isActive || commentsCount">
-  <i class="fa" ng-class="{'fa-comment': commentsCount, 'fa-comment-o': !commentsCount}"></i>
+  <span class="icon-count-container">
+    <i class="fa" ng-class="{'fa-comment': commentsCount, 'fa-comment-o': !commentsCount}"></i>
+    <span ng-show="commentsCount">{{commentsCount}}</span>
+  </span>
 </div>


### PR DESCRIPTION
Using $emit instead of $broadcast as well as dropping deep $watching gives a big boast of performance.

We also now show comments count per paragraph.