### PR TITLE
Fix suggested next reading issue

### DIFF
--- a/backend/app/models/article.rb
+++ b/backend/app/models/article.rb
@@ -39,7 +39,11 @@ class Article < ActiveRecord::Base
   end
 
   def next
-    Article.public.popular.where('hotness < ?', hotness).first
+    next_article = Article.public.popular.where('hotness < ?', hotness).first
+    if next_article.nil?
+        next_article = Article.public.popular.where('hotness > ?', hotness).first
+    end
+    next_article
   end
   
   def time_to_read


### PR DESCRIPTION
The "next" method in the "article" model was set to return the less-hot
article than the current, that wasn't work with the least-hottest article
in the list. I modified the method to return the hottest-article as the next
of the very least-hottest one.