### PR TITLE
Fix a small redirect ux-issue in drafts deleting

### DIFF
--- a/web-client/app/scripts/controllers/editArticleController.js
+++ b/web-client/app/scripts/controllers/editArticleController.js
@@ -104,7 +104,7 @@ angular.module('webClientApp')
       $analytics.eventTrack('Article Deleted', {
         category: 'Article'
       });
-      $location.path('/');
+      $location.path('/profiles/' + $rootScope.currentUser.id);
     };
 
     var deleteError = function (response) {


### PR DESCRIPTION
After deleting a draft from within itself, users were redirected to the homepage. Instead, I modified the redirection to the user own profile.

A use-case before the modification:
A user checking his own profile -> opened a draft -> deleted it -> redirected to the homepage.

A use-case after the modification:
A user checking his own profile -> opened a draft -> deleted it -> redirected to his profile again.

Side note: This modification was suggested by @ahmgeek