### PR TITLE
Fix a redirection UX-issue in drafts deleting

### DIFF
--- a/web-client/app/scripts/controllers/editArticleController.js
+++ b/web-client/app/scripts/controllers/editArticleController.js
@@ -103,7 +103,7 @@ angular.module('webClientApp')
       $analytics.eventTrack('Article Deleted', {
         category: 'Article'
       });
-      $location.path('/');
+      $location.path('/profiles/' + $rootScope.user.id);
     };
 
     var deleteError = function (response) {

--- a/web-client/test/spec/controllers/editArticleController.js
+++ b/web-client/test/spec/controllers/editArticleController.js
@@ -140,6 +140,7 @@ describe('Controller: EditArticleCtrl', function () {
 
   describe('EditArticleCtrl.deleteArticle', function () {
     it('should delete an article when the user confirm', function () {
+      rootScope.user = {id: 1};
       createController();
       spyOn(mock, 'confirm').andCallFake(function() {return true;});
       spyOn(ArticleModel, 'delete').andCallFake(function(params, data, success) {
@@ -148,7 +149,7 @@ describe('Controller: EditArticleCtrl', function () {
       scope.deleteArticle({id: 1});
       expect(mock.confirm).toHaveBeenCalled();
       expect(ArticleModel.delete).toHaveBeenCalled();
-      expect(location.path()).toBe('/');
+      expect(location.path()).toBe('/profiles/1');
     });
 
     it('should not delete an article when the user does not confirm', function () {


### PR DESCRIPTION
After deleting a draft from within itself, users were redirected to the homepage. Instead, I modified the redirection to the user own profile.

A use-case before the modification:
A user checking his own profile -> opened a draft -> deleted it -> redirected to the homepage.

A use-case after the modification:
A user checking his own profile -> opened a draft -> deleted it -> redirected to his profile again.

Side note: This modification was suggested by @ahmgeek