### PR TITLE
Fix users redirection and hide writer-details card

### DIFF
--- a/web-client/app/scripts/controllers/editArticleController.js
+++ b/web-client/app/scripts/controllers/editArticleController.js
@@ -203,7 +203,7 @@ angular.module('webClientApp')
     });
 
     /**
-     * When the user logout while in edit mdoe redirect the user,
+     * When the user logout while in edit mode redirect the user,
      */
     var loggedOutUnbined = $rootScope.$on('auth:logout-success', function () {
       if ($scope.article.published) {

--- a/web-client/app/scripts/controllers/editProfileController.js
+++ b/web-client/app/scripts/controllers/editProfileController.js
@@ -130,4 +130,19 @@ angular.module('webClientApp')
       $scope.inProgress = null;
     };
 
+
+    /**
+     * When the user logout while in edit mode, redirect the user to his
+     * own profile
+     */
+    var loggedOutUnbined = $rootScope.$on('auth:logout-success', function () {
+      $location.path('/profiles/' + $routeParams.userId);
+    });
+
+    var onDestroy = function () {
+      loggedOutUnbined();
+    };
+
+    $scope.$on('$destroy', onDestroy);
+
   }]);

--- a/web-client/app/views/articles/show.html
+++ b/web-client/app/views/articles/show.html
@@ -43,7 +43,7 @@
         <h1 class="header-label">
           <span>بقلم</span>
         </h1>
-        <div class="meta-details card">
+        <div class="meta-details card" ng-hide="article.loading">
           <a class="meta-thumb" ng-href="/profiles/{{article.user.id}}">
             <img ng-src="{{article.user.thumb_url}}" />
           </a>


### PR DESCRIPTION
Added a listener to redirect the user to his own profile if he logged-out while editing his details.

Also set the writer-details card to be hidden while article loading.