### PR TITLE
Make pre tags scrollable.

### DIFF
--- a/web-client/app/styles/main.scss
+++ b/web-client/app/styles/main.scss
@@ -1153,6 +1153,7 @@ ul.cards-list-container {
         margin: 10px;
         display: block;
         padding-top: 1em;
+        overflow: scroll;
       }
 
       blockquote {


### PR DESCRIPTION
Fixes the issue here https://github.com/manshar/manshar/issues/190

If highlight.js fails to load for whatever reason the fallback will be
that users will scroll inside the pre tag instead.

_Personally_ I don't like wrapping code inside `pre` tags, so maybe it's
a good idea overall :)