### PR TITLE
Autoamting forcing Style Guide.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,16 @@
+# EditorConfig is awesome: http://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+charset = utf-8
+indent_style = space
+indent_size = 2
+end_of_line = lf
+insert_final_newline = true
+
+# Markdown needs whitespace.
+[*.md]
+trim_trailing_whitespace = false


### PR DESCRIPTION
This will automatically force code Style Guide https://github.com/manshar/manshar/wiki/Style-Guide#across-manshar-codebase when you have the [editorconfig](http://editorconfig.org/#download) plugin.

It's used by [major projects](https://github.com/editorconfig/editorconfig/wiki/Projects-Using-EditorConfig) to keep code consistent.