### PR TITLE
rename fig.yml to docker-compose.yml and updated dev env docs to use …

### DIFF
--- a/DEVELOPMENT_ENVIRONMENT.md
+++ b/DEVELOPMENT_ENVIRONMENT.md
@@ -1,7 +1,7 @@
 # Introduction
 
 This short guide helps you setup a consistent [Docker](https://www.docker.com/) based development environment for Manshar. 
-It makes use of [fig](http://www.fig.sh/) to instantiate a set of containers to run a development instance of Manshar.
+It makes use of [docker-compose](https://docs.docker.com/compose/) to instantiate a set of containers to run a development instance of Manshar.
 
 # Install Pre-requisites:
 ## Docker
@@ -11,8 +11,8 @@ A docker host will run the Manshar containers that are necessary to run the weba
 If you are already using a linux machine for development, you may use the same machine as the containers host.
 Otherwise, you will need access to a linux machine for that purpose.
 The easiet way to achieve the latter is to spin a linux VM on your development machine.
-We recommend using boot2docker, which is a preconfigured virtualbox linux VM that has docker pre-installed on it.
-In addition, boot2docker provides a simple CLI tool to manage the docker host VM.
+We recommend using docker-machine, which creates a preconfigured virtualbox linux VM that has docker pre-installed on it.
+In addition, docker-machine provides a simple CLI tool to manage the docker host VM.
 
 ### Docker on Linux
 
@@ -21,40 +21,45 @@ You can find the installation instructions for your distribution [here](https://
 
 ### Docker on Mac OSX (and Windows, just in case)
 
-Install boot2docker as per the instructions that can be found [here](http://boot2docker.io/).
-After installing boot2docker, make sure to initialize the boot2docker VM by running:
+Install the docker toolbox as per the instructions that can be found [here](https://www.docker.com/toolbox). The toolbox will install virtualbox, docker, docker-compose, and docker-machine.
+After installing the toolbox, make sure to initialize the docker-machine VM by running:
 
 ```bash
-$ boot2docker init
+$ docker-machine create -d virtualbox default
 ```
 
-## Fig
+### Docker on Ubuntu
 
-Install Fig as described in the instructions [here](http://www.fig.sh/install.html)
+Run the following commands and you can skip everything related to docker-machine in the instructions since Ubuntu is a Linux distro which can run containers on bare metal.
+
+1. [Install Docker](https://docs.docker.com/installation/ubuntulinux/#install) and don't forget to [setup the docker group](https://docs.docker.com/installation/ubuntulinux/#create-a-docker-group)
+2. [Install Docker Compose](https://docs.docker.com/compose/install/)
+
+## Docker Compose
 
 # Initialize the Development Containers:
 
-## Boot2docker Initialization Pre-requisites
+## Docker Machine Initialization Pre-requisites
 
-If you are using boot2docker, make sure to run the following two commands first:
+If you are using docker-machine, make sure to run the following two commands first:
 ```bash
-$ boot2docker up
-$ $(boot2docker shellinit)
+$ docker-machine start default
+$ eval $(docker-machine env default)
 ```
-The first of these commands will make sure that the boot2docker VM is up and running.
-The second command will initialize some environment variables that are used by the 'docker' CLI tool so that it knows which docker server it should talk to (the one running on the boot2docker VM).
+The first of these commands will make sure that the docker-machine VM is up and running.
+The second command will initialize some environment variables that are used by the 'docker' CLI tool so that it knows which docker server it should talk to (the one running on the docker-machine VM).
 
-Note that these two commands should always be run when restarting the boot2docker VM.
+Note that these two commands should always be run when restarting the docker-machine VM or running in a new terminal session.
 
 ## Common Initialization Instructions
 
-* Edit the fig.yml and replace the 'dockerhost' strings with the IP address or hostname of the docker host. In the case you are using boot2docker, you can figure out the VM IP address by running:
+* Edit the docker-compose.yml and replace the 'dockerhost' strings with the IP address or hostname of the docker host. In the case you are using docker-machine, you can figure out the VM IP address by running:
 ```bash
-$ boot2docker ip
+$ docker-machine ip default
 ```
 * Initialize the database container by running the following command:
 ```bash
-$ fig run backend ./init_db.sh
+$ docker-compose run backend ./init_db.sh
 ```
 Note that running these commands might take a significant amount of time, depending on your Internet connection.
 The reason being that these commands will pull the Manshar's development environment docker containers from docker hub.
@@ -65,14 +70,13 @@ Once these commands finish runing, you're development environment should be read
 
 Running the Manshar servers is as simple as running:
 ```bash
-$ fig up
+$ docker-compose up
 ```
 
 ## Stopping the Development Services:
 
-The reverse of `up` is `down`:
 ```bash
-$ fig down
+$ docker-compose stop
 ```
 
 ## Installing Extra Packages in a Container
@@ -81,18 +85,17 @@ This depends on which container you want to install extra packages to.
 For example, if you need to install packages to the 'web' container, you can run
 
 ```bash
-$ fig run web npm install <whatever-package>
+$ docker-compose run web npm install <whatever-package>
 ```
 
 ## Other Stuff
-For More Information on How to Deal with Docker Containers and Fig, checkout the [docker](https://docs.docker.com/) and [fig](http://www.fig.sh/) documentation.
+For More Information on How to Deal with Docker Containers and Fig, checkout the [docker](https://docs.docker.com/) and [docker-compose](https://docs.docker.com/compose/) documentation.
 
 
 ## Troubleshooting
 ### x509: certificate has expired or is not yet valid
-If you get this message when running any docker or fig commands, restart the boot2docker VM by running:
+If you get this message when running any docker or docker-compose commands, restart the docker-machine VM by running:
 ```bash
-$ boot2docker down
-$ boot2docker up
+$ docker-machine restart default
 ```
 And then run your command again.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ backend:
     DRAGONFLY_SECRET: c2jq0a9cj039jc01mamc09qjc930ur10fjafj0a9fj09fj23qnweocn0qwf0qfjq
     MANSHAR_DB_1_PORT_5432_TCP_ADDR: db
   volumes:
-    - backend/:/manshar-backend
+    - ./backend/:/manshar-backend
   ports:
     - "3000:3000"
   links:
@@ -27,6 +27,6 @@ web:
     PORT: 9000
     API_HOST: dockerhost:3000
   volumes:
-    - web-client/:/manshar-web-client
+    - ./web-client/:/manshar-web-client
   ports:
     - "9000:9000"


### PR DESCRIPTION
…docker-compose and docker-machine instead of fig and boot2docker respectively. Both fig and boot2docker cli have been officially deprecated by Docker a while back.