### PR TITLE
Fix gem versions.

### DIFF
--- a/backend/Gemfile
+++ b/backend/Gemfile
@@ -6,8 +6,8 @@ gem 'rails', '4.2'
 gem 'pg', platform: :ruby
 
 # Authentication and Registration mechanism.
-gem 'devise', git: 'https://github.com/plataformatec/devise.git'
-gem 'devise_token_auth', '0.1.30'
+gem 'devise'
+gem 'devise_token_auth'
 gem 'omniauth-facebook'
 gem 'omniauth-gplus', '~> 2.0'
 
@@ -45,7 +45,7 @@ gem 'mailboxer', git: 'git://github.com/div/mailboxer.git', :branch => 'rails42-
 
 # Allows styling emails HTML with non-inline styles.
 gem 'hpricot'
-gem 'premailer-rails'
+gem 'premailer-rails', '1.9.4'
 gem 'roadie'
 gem 'roadie-rails'
 

--- a/backend/Gemfile.lock
+++ b/backend/Gemfile.lock
@@ -7,18 +7,6 @@ GIT
       carrierwave (>= 0.5.8)
       rails (>= 3.2.0)
 
-GIT
-  remote: https://github.com/plataformatec/devise.git
-  revision: a2e0e9c187dd58618e234c2a790d6723d5792e74
-  specs:
-    devise (3.4.1)
-      bcrypt (~> 3.0)
-      orm_adapter (~> 0.1)
-      railties (>= 3.2.6, < 5)
-      responders
-      thread_safe (~> 0.1)
-      warden (~> 1.2.3)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -64,7 +52,7 @@ GEM
       addressable (>= 2.3.1)
       extlib (>= 0.9.15)
       multi_json (>= 1.0.0)
-    bcrypt (3.1.10)
+    bcrypt (3.1.11)
     builder (3.2.2)
     carrierwave (0.10.0)
       activemodel (>= 3.2.0)
@@ -77,6 +65,13 @@ GEM
     css_parser (1.3.6)
       addressable
     daemons (1.2.3)
+    devise (3.5.10)
+      bcrypt (~> 3.0)
+      orm_adapter (~> 0.1)
+      railties (>= 3.2.6, < 5)
+      responders
+      thread_safe (~> 0.1)
+      warden (~> 1.2.3)
     devise_token_auth (0.1.30)
       devise (~> 3.3)
       rails (~> 4.1)
@@ -285,11 +280,11 @@ GEM
     persistize (0.2.0)
       activerecord
     pg (0.18.1)
-    premailer (1.8.3)
+    premailer (1.8.6)
       css_parser (>= 1.3.6)
-      htmlentities (>= 4.0.0, <= 4.3.1)
-    premailer-rails (1.8.0)
-      actionmailer (>= 3, < 5)
+      htmlentities (>= 4.0.0)
+    premailer-rails (1.9.4)
+      actionmailer (>= 3, < 6)
       premailer (~> 1.7, >= 1.7.9)
     puma (2.11.0)
       rack (>= 1.1, < 2.0)
@@ -341,8 +336,8 @@ GEM
     redis (3.2.0)
     redis-namespace (1.5.1)
       redis (~> 3.0, >= 3.0.4)
-    responders (2.1.0)
-      railties (>= 4.2.0, < 5)
+    responders (2.3.0)
+      railties (>= 4.2.0, < 5.1)
     retriable (1.4.1)
     roadie (3.0.3)
       css_parser (~> 1.3.4)
@@ -406,7 +401,7 @@ GEM
     trollop (2.1.2)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
-    warden (1.2.3)
+    warden (1.2.6)
       rack (>= 1.0)
     xml-simple (1.1.5)
 
@@ -414,8 +409,8 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  devise!
-  devise_token_auth (= 0.1.30)
+  devise
+  devise_token_auth
   dotenv-rails
   dragonfly
   dragonfly-s3_data_store
@@ -432,7 +427,7 @@ DEPENDENCIES
   omniauth-gplus (~> 2.0)
   persistize
   pg
-  premailer-rails
+  premailer-rails (= 1.9.4)
   puma
   pundit
   rabl

--- a/web-client/bower.json
+++ b/web-client/bower.json
@@ -34,6 +34,7 @@
     "angular-scenario": "~1.5.0"
   },
   "resolutions": {
-    "angular": "~1.5.0"
+    "angular": "~1.5.0",
+    "angular-cookie": "~4.1.0"
   }
 }

--- a/web-client/package.json
+++ b/web-client/package.json
@@ -34,7 +34,7 @@
     "gulp-changed-in-place": "^2.0.3",
     "gulp-clean": "^0.3.1",
     "gulp-concat": "^2.6.0",
-    "gulp-cssnano": "^2.1.1",
+    "gulp-cssnano": "2.1.1",
     "gulp-eslint": "^2.0.0",
     "gulp-filter": "^3.0.1",
     "gulp-google-cdn": "^2.1.0",
@@ -82,6 +82,7 @@
     "run-sequence": "^1.1.5",
     "serve-index": "^1.7.3",
     "serve-static": "^1.10.2",
+    "svgo": "^0.6.1",
     "sw-precache": "git://github.com/mkhatib/sw-precache"
   },
   "engines": {


### PR DESCRIPTION
Previous builds broke with.
```
Bundler could not find compatible versions for gem "htmlentities":
  In snapshot (Gemfile.lock):
    htmlentities (= 4.3.4)
  In Gemfile:
    premailer-rails was resolved to 1.8.0, which depends on
      premailer (>= 1.7.9, ~> 1.7) was resolved to 1.8.3, which depends on
        htmlentities (<= 4.3.1, >= 4.0.0)
```